### PR TITLE
Improve StatefulSets + Services

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.6
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/haproxy-services.yaml
+++ b/templates/haproxy-services.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels: {{ include "jitsi.haproxy.labels" $ | nindent 4 }}
 spec:
+  clusterIP: None
   ports:
   - name: http
     port: 8080

--- a/templates/jvb-services.yaml
+++ b/templates/jvb-services.yaml
@@ -1,4 +1,20 @@
 {{- range $shard, $e := until (int $.Values.shardCount) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels: {{ include "jitsi.jvbShard.labels" (merge (dict "RelativeScope" (dict "shard" $shard)) $) | nindent 4 }}
+  name: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-jvb
+  namespace: {{ $.Release.Namespace }}
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+  - name: "metrics"
+    protocol: "TCP"
+    port: 9888
+    targetPort: metrics
+  selector: {{ include "jitsi.jvbShard.selectorLabels" (merge (dict "RelativeScope" (dict "shard" $shard)) $) | nindent 4 }}
 {{- range $replica, $f := until (int $.Values.jvb.replicas) }}
 {{ if empty $.Values.jvb.hostPort }}
 ---
@@ -21,26 +37,5 @@ spec:
     statefulset.kubernetes.io/pod-name: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-jvb-{{ $replica }}
     {{ include "jitsi.jvbShard.labels" (merge (dict "RelativeScope" (dict "shard" $shard)) $) | nindent 4 }}
 {{ end -}}
----
-apiVersion: v1
-kind: Service
-metadata:
-{{ with $.Values.jvb.monitoring.service.extraAnnotations }}
-  annotations:
-    {{ toYaml . | nindent 4 }}
-{{ end }}
-  labels: {{ include "jitsi.jvbReplicaMonitoring.labels" (merge (dict "RelativeScope" (dict "shard" $shard "replica" $replica)) $) | nindent 4 }}
-  name: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-jvb-{{ $replica }}-metrics
-  namespace: {{ $.Release.Namespace }}
-spec:
-  type: ClusterIP
-  ports:
-  - name: "metrics"
-    protocol: "TCP"
-    port: 9888
-    targetPort: metrics
-  selector:
-    statefulset.kubernetes.io/pod-name: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-jvb-{{ $replica }}
-    {{ include "jitsi.jvbShard.labels" (merge (dict "RelativeScope" (dict "shard" $shard)) $) | nindent 4 }}
 {{ end -}}
 {{ end -}}

--- a/templates/jvb-statefulset.yaml
+++ b/templates/jvb-statefulset.yaml
@@ -17,7 +17,7 @@ spec:
   replicas: {{ $.Values.jvb.replicas }}
   selector:
     matchLabels: {{ include "jitsi.jvbShard.selectorLabels" (merge (dict "RelativeScope" (dict "shard" $shard)) $) | nindent 6 }}
-  serviceName: jvb
+  serviceName: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-jvb
   template:
     metadata:
       labels: {{ include "jitsi.jvbShard.labels" (merge (dict "RelativeScope" (dict "shard" $shard)) $) | nindent 8 }}


### PR DESCRIPTION
Ensure that `StatefulSet.spec.serviceName` points to a `Service` that
* exists
* has `Service.spec.clusterIP: None`

As a result we also move from 1 `Service` per JVB shard-replica, to 1 `Service` per JVB 