### PR TITLE
Sysctl JVB: take version out of matchLabels

### DIFF
--- a/templates/sysctl-jvb-daemonset.yaml
+++ b/templates/sysctl-jvb-daemonset.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   selector:
-    matchLabels: {{ include "jitsi.sysctlJvb.labels" $ | nindent 6 }}
+    matchLabels: {{ include "jitsi.sysctlJvb.selectorLabels" $ | nindent 6 }}
   template:
     metadata:
       labels: {{ include "jitsi.sysctlJvb.labels" $ | nindent 8 }}


### PR DESCRIPTION
Stop having to recreate the DaemonSet on chart upgrade as `spec.selector.matchLabels` was changing which isn't allowed